### PR TITLE
Add R CMD checks for every push and PR

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -1,0 +1,37 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+#
+# See https://github.com/r-lib/actions/tree/master/examples#readme for
+# additional example workflows available for the R community.
+
+name: R
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: macOS-latest
+    strategy:
+      matrix:
+        r-version: [3.5, 3.6]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up R ${{ matrix.r-version }}
+        uses: r-lib/actions/setup-r@ffe45a39586f073cc2e9af79c4ba563b657dc6e3
+        with:
+          r-version: ${{ matrix.r-version }}
+      - name: Install dependencies
+        run: |
+          install.packages(c("remotes", "rcmdcheck"))
+          remotes::install_deps(dependencies = TRUE)
+        shell: Rscript {0}
+      - name: Check
+        run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "error")
+        shell: Rscript {0}


### PR DESCRIPTION
I added a GH Action that runs the R CMD check with every PR or push. Currently, it runs on R 3.5 and 3.6 but this can be easily changed in `.github/workflows/r.yml`  A couple of observations:
- I don't think I have correct read and write access rights to the repo as I couldn't push new branches to the origin, thus this fork
- anyone can easily set up this GH Action using R by running `usethis::use_github_acitons()` (but it's less straightforward in forked repos!)
- the R CDM check fails due to an unexpected pipe in `get_eurostat_indicator.R` 